### PR TITLE
use Number.MAX_SAFE_INTEGER if defined for node 0.12.x+

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ Heart.prototype.stop = function() {
 
 var sse = {
   prepare: function prepareServerEventResponse (req, res, init) {
-    req.socket.setTimeout(Infinity);
+    req.socket.setTimeout(Number.MAX_SAFE_INTEGER || Infinity);
     res.writeHead(200, {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",


### PR DESCRIPTION
- ```socket.setTimeout()``` argument must be finite on node 0.12.x+